### PR TITLE
Only support Py3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,7 @@ language:
   python
 
 python:
-  - 3.3
-  - 3.4
-  - 3.5
+  - 3.6
 
 env:
     global:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Build Status](https://travis-ci.org/openspending/gobble.svg?branch=master)](https://travis-ci.org/openspending/gobble)
+[![Coveralls](http://img.shields.io/coveralls/openspending/gobble/master.svg)](https://coveralls.io/r/openspending/gobble?branch=master)
 
 # Gobble
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Gobble
 
-Gobble is the client API for [Open-Spending](next.openspending.org), an international platform to package, share and visualize budget data. Gobble does exactly the same thing as the [packager interface](next.openspending.org/packager), except programatically. It can be used both as python client or a command line interface. It's compatible with versions 3.3, 3.4, 3.5. Support for 2.7 is in the works. You can install it via `pip`.
+Gobble is the client API for [Open-Spending](next.openspending.org), an international platform to package, share and visualize budget data. Gobble does exactly the same thing as the [packager interface](next.openspending.org/packager), except programatically. It can be used both as python client or a command line interface. It's compatible with python version 3.6. You can install it via `pip`.
 
 ```
 pip install os-gobble

--- a/assets/datapackage/invalid.json
+++ b/assets/datapackage/invalid.json
@@ -1,5 +1,6 @@
 {
     "name": "invalid-no-mapping-amount",
+    "profile": "fiscal-data-package",
     "owner": "me",
     "openspending": {
         "mapping": {

--- a/gobble/api.py
+++ b/gobble/api.py
@@ -1,10 +1,4 @@
 """This module handles all API calls"""
-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 from builtins import str
 from requests import HTTPError
 from requests import Session

--- a/gobble/api.py
+++ b/gobble/api.py
@@ -12,7 +12,6 @@ from urllib.parse import (urlencode,
                           urljoin,
                           urlunsplit,
                           urlsplit)
-from json import JSONDecodeError
 
 from gobble.config import settings
 from gobble.logger import log
@@ -112,7 +111,4 @@ def handle(response):
         log.error(error)
         raise error
 
-    try:
-      return to_json(response)
-    except JSONDecodeError:
-        return {}
+    return to_json(response)

--- a/gobble/config.py
+++ b/gobble/config.py
@@ -1,10 +1,4 @@
 """This module exposes user configurable settings"""
-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 from logging import DEBUG
 from os import getenv
 from os import mkdir
@@ -12,9 +6,6 @@ from os.path import isdir
 from os.path import join, abspath, dirname, expanduser
 from sys import modules
 
-from future import standard_library
-
-standard_library.install_aliases()
 
 HOME_DIR = abspath(join(expanduser('~')))
 ROOT_DIR = abspath(join(dirname(__file__), '..'))

--- a/gobble/fiscal.py
+++ b/gobble/fiscal.py
@@ -14,7 +14,7 @@ from io import StringIO
 from os.path import getsize, join, basename, isfile
 from time import sleep
 from json import dumps, loads, JSONDecodeError
-from datapackage import DataPackage
+from datapackage import DataPackage, Profile
 from datapackage.exceptions import ValidationError
 from future import standard_library
 from gobble.user import User
@@ -110,19 +110,19 @@ class FiscalDataPackage(DataPackage):
         :return A list of error messages or an empty list.
         """
         messages = []
+        profile = Profile('fiscal-data-package')
 
         if raise_on_error:
-            super(FiscalDataPackage, self).validate()
+            profile.validate(self.descriptor)
         else:
             try:
-                super(FiscalDataPackage, self).validate()
+                profile.validate(self.descriptor)
                 message = '%s (%s) is a valid fiscal data-package schema'
                 log.info(message, self.path, self)
-
-            except ValidationError:
-                for error in self.iter_errors():
+            except ValidationError as e:
+                for error in e.errors:
                     message = 'SCHEMA ERROR in %s: %s'
-                    args = self.path, error.message
+                    args = self.path, error
                     messages.append(message % args)
                     log.warn(message, *args)
 

--- a/gobble/fiscal.py
+++ b/gobble/fiscal.py
@@ -189,14 +189,14 @@ class FiscalDataPackage(DataPackage):
 
         query = dict(datapackage=self._descriptor_s3_url)
         try:
-           answer = loads(upload_status(params=query).text)
+            answer = loads(upload_status(params=query).text)
         except JSONDecodeError:
-           return True
+            return True
         args = self, answer['status'], answer['progress'], len(self)
         log.debug('%s is loading (%s) %s/%s', *args)
         if answer['status'] == 'fail':
             raise UploadError(answer.get('error'))
-        
+
         return answer['status'] not in {'done', 'fail'}
 
     def toggle(self, to_state):

--- a/gobble/fiscal.py
+++ b/gobble/fiscal.py
@@ -1,10 +1,4 @@
 """ This modules uploads data-packages to the Open-Spending datastore"""
-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 import io
 import sys
 
@@ -16,7 +10,6 @@ from time import sleep
 from json import dumps, loads, JSONDecodeError
 from datapackage import DataPackage, Profile
 from datapackage.exceptions import ValidationError
-from future import standard_library
 from gobble.user import User
 from goodtables.pipeline import Pipeline
 from requests import HTTPError
@@ -29,8 +22,6 @@ from gobble.api import (handle,
                         request_upload,
                         toggle_publish,
                         upload_status)
-
-standard_library.install_aliases()
 
 
 HASHING_BLOCK_SIZE = 65536

--- a/gobble/logger.py
+++ b/gobble/logger.py
@@ -1,11 +1,4 @@
 """A simple logger that logs to file and console"""
-
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-
-from future import standard_library
 from logging import (getLogger,
                      FileHandler,
                      StreamHandler,
@@ -14,8 +7,6 @@ from logging import (getLogger,
                      Filter)
 
 from gobble.config import settings, GOBBLE_MODE
-
-standard_library.install_aliases()
 
 
 class MultilineFilter(Filter):

--- a/gobble/search.py
+++ b/gobble/search.py
@@ -1,6 +1,4 @@
 """Search for users and package inside the ElasticSearch database"""
-
-
 from gobble.api import search_packages, handle
 from gobble.user import User
 

--- a/gobble/snapshot.py
+++ b/gobble/snapshot.py
@@ -1,6 +1,4 @@
 """This module has good intentions, like helping you debug API calls"""
-
-
 from collections import OrderedDict
 from copy import deepcopy
 from datetime import datetime

--- a/gobble/user.py
+++ b/gobble/user.py
@@ -1,16 +1,9 @@
 """Manage user authentication and authorization"""
-
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-
 import io
 import os
 
 from builtins import dict
-from future import standard_library
-from future.backports.http.server import HTTPServer, SimpleHTTPRequestHandler
+from http.server import HTTPServer, SimpleHTTPRequestHandler
 from os.path import join
 from json import loads
 from os import mkdir
@@ -23,8 +16,6 @@ from gobble.api import (handle,
                         authenticate_user,
                         authorize_user,
                         oauth_callback)
-
-standard_library.install_aliases()
 
 
 OS_SERVICES = ['os.datastore']

--- a/package.json
+++ b/package.json
@@ -14,12 +14,8 @@
     "Environment :: Web Environment",
     "Intended Audience :: Developers",
     "Operating System :: OS Independent",
-    "Programming Language :: Python :: 2",
-    "Programming Language :: Python :: 2.7",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.3",
-    "Programming Language :: Python :: 3.4",
-    "Programming Language :: Python :: 3.5",
+    "Programming Language :: Python :: 3.6",
     "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
     "Topic :: Software Development :: Libraries :: Python Modules"
   ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 click
 requests
 requests-futures
-datapackage
+datapackage>1.0.0
 goodtables<1.0.0

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 from json import loads
 from os.path import join, dirname
 from setuptools import setup, find_packages

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,10 +1,4 @@
 """Fixtures for test modules"""
-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 import io
 from json import loads
 from os import makedirs
@@ -12,15 +6,12 @@ from os.path import join, expanduser
 from shutil import rmtree
 from unittest.mock import patch
 
-from future import standard_library
 from gobble.snapshot import SNAPSHOTS_DIR
 from pytest import fixture
 
 from gobble import FiscalDataPackage
 from gobble.config import settings, GOBBLE_MODE
 from gobble.config import ROOT_DIR
-
-standard_library.install_aliases()
 
 
 # Devlopment mode required

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,19 +1,11 @@
 """Test the API module."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 import responses
-from future import standard_library
 from pytest import mark, raises
 from requests import HTTPError
 
 from gobble.api import handle
 from tests.parameters import api_calls
-
-standard_library.install_aliases()
 
 
 @responses.activate

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -1,17 +1,8 @@
 """Test the configuration module"""
-
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-
 from urllib.parse import urlparse
 
-from future import standard_library
 from os.path import isdir, dirname
 from pytest import mark
-
-standard_library.install_aliases()
 
 from gobble.config import ROOT_DIR, HOME_DIR, GOBBLE_MODE
 from tests.parameters import configurations
@@ -24,7 +15,7 @@ def test_log_levels_are_set(settings):
 
 
 @mark.parametrize('settings', configurations)
-def test_log_levels_are_set(settings):
+def test_log_file_is_str(settings):
     assert isinstance(settings.LOG_FILE, str)
 
 

--- a/tests/test_fiscal.py
+++ b/tests/test_fiscal.py
@@ -6,7 +6,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 
-from datapackage.exceptions import ValidationError
+import datapackage
 from future import standard_library
 from os.path import join
 from pytest import raises
@@ -28,24 +28,25 @@ def test_compute_hash_returns_correct_hash():
 
 
 # noinspection PyShadowingNames
-def test_validate_bad_package_with_raise_error_false(invalid_fiscal_package):
-    report = invalid_fiscal_package.validate(
+def test_validate_bad_package_with_raise_error_false():
+    report = invalid_fiscal_package().validate(
         raise_on_error=False,
         schema_only=True
     )
     assert isinstance(report, list)
-    assert 'is a required property' in report[0]
+    assert len(report) > 0
+    # assert 'is a required property' in report[0]
 
 
 # noinspection PyShadowingNames
-def test_validate_bad_package_raises_error_by_default(invalid_fiscal_package):
-    with raises(ValidationError):
-        invalid_fiscal_package.validate()
+def test_validate_bad_package_raises_error_by_default():
+    with raises(datapackage.exceptions.ValidationError):
+        invalid_fiscal_package().validate()
 
 
 # noinspection PyShadowingNames
-def test_validate_returns_true_for_valid_package(fiscal_package):
-    report = fiscal_package.validate(
+def test_validate_returns_true_for_valid_package():
+    report = fiscal_package().validate(
         raise_on_error=False,
         schema_only=True
     )

--- a/tests/test_fiscal.py
+++ b/tests/test_fiscal.py
@@ -24,7 +24,6 @@ def test_validate_bad_package_with_raise_error_false():
     )
     assert isinstance(report, list)
     assert len(report) > 0
-    # assert 'is a required property' in report[0]
 
 
 # noinspection PyShadowingNames

--- a/tests/test_fiscal.py
+++ b/tests/test_fiscal.py
@@ -1,13 +1,5 @@
 """Tests for the uploader module"""
-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
-
 import datapackage
-from future import standard_library
 from os.path import join
 from pytest import raises
 
@@ -15,9 +7,6 @@ from pytest import raises
 from tests.fixtures import fiscal_package, invalid_fiscal_package
 from gobble.config import ROOT_DIR
 from gobble.fiscal import compute_hash
-
-
-standard_library.install_aliases()
 
 
 DATA_FILE = join(ROOT_DIR, 'assets', 'datapackage', 'data', 'data.csv')

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,14 +1,6 @@
 """Test the logger module"""
 
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-
 from logging import FileHandler, StreamHandler, Logger, LogRecord
-from future import standard_library
-
-standard_library.install_aliases()
 
 from gobble.logger import log, MultilineFilter
 

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -1,17 +1,9 @@
 """Tests for the user maodule"""
 
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-
 import responses
-from future import standard_library
 from requests import Response
 
 from gobble.api import authenticate_user
-
-standard_library.install_aliases()
 
 
 @responses.activate

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,5 @@
 [tox]
 package=gobble
-skip_missing_interpreters=true
 envlist=
   py36
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,22 @@
 [tox]
-envlist =
-    py36
+package=gobble
+skip_missing_interpreters=true
+envlist=
+  py36
 
 [testenv]
-deps = -rrequirements.dev.txt
-commands = py.test tests --cov gobble --cov-report term-missing {posargs}
-passenv = *
+deps=
+  -rrequirements.dev.txt
+passenv=
+  CI
+  TRAVIS
+  TRAVIS_JOB_ID
+  TRAVIS_BRANCH
+setenv=
+  GOBBLE_MODE=Development
+commands=
+  py.test \
+    --cov {[tox]package} \
+    --cov-config tox.ini \
+    --cov-report term-missing \
+    {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [tox]
-envlist = py33, py34, py35
+envlist =
+    py36
 
 [testenv]
 deps = -rrequirements.dev.txt


### PR DESCRIPTION
Dropping other python support, other than py3.6. Also fixes tests to work with datapackage>1.0.0.

Connected to openspending/openspending#1302 and openspending/openspending#1326.